### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android_fastlane.yml
+++ b/.github/workflows/android_fastlane.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests


### PR DESCRIPTION
Potential fix for [https://github.com/thoser666/Vivid/security/code-scanning/7](https://github.com/thoser666/Vivid/security/code-scanning/7)

Add an explicit `permissions` block in `.github/workflows/android_fastlane.yml` at the workflow root (right after `on` and before `jobs`) so it applies consistently to all jobs unless overridden.  
Best minimal fix without changing functionality: set:

- `contents: read`

This matches CodeQL’s minimal recommendation and supports `actions/checkout` and typical read operations while reducing token privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
